### PR TITLE
Regenerate api code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ Generating code
 
 .. code-block:: shell
 
-    oapi-codegen -generate server -package api docs/_static/nuts-event-store.yaml > api/generated.go
+    oapi-codegen -generate server,types -package api docs/_static/nuts-event-store.yaml > api/generated.go
 
 Generating Mock
 ***************

--- a/api/addons.go
+++ b/api/addons.go
@@ -35,12 +35,12 @@ func convert(e pkg.Event) Event {
 	}
 }
 
-func convertList(e *[]pkg.Event) []Event {
+func convertList(e *[]pkg.Event) *[]Event {
 	events := make([]Event, len(*e))
 
 	for i, el := range *e {
 		events[i] = convert(el)
 	}
 
-	return events
+	return &events
 }

--- a/pkg/events.go
+++ b/pkg/events.go
@@ -524,7 +524,7 @@ func (octopus *EventOctopus) startSubscribers() error {
 			return
 		}
 
-		if event.RetryCount >= int32(octopus.Config.MaxRetryCount) {
+		if event.RetryCount >= int(octopus.Config.MaxRetryCount) {
 			event.Name = EventErrored
 			errStr := "max retry count reached"
 			event.Error = &errStr

--- a/pkg/events_test.go
+++ b/pkg/events_test.go
@@ -406,7 +406,7 @@ func TestEventOctopus_Retry(t *testing.T) {
 		wg.Wait()
 
 		assert.Equal(t, uuid, receivedEvent.UUID)
-		assert.Equal(t, int32(1), receivedEvent.RetryCount)
+		assert.Equal(t, int(1), receivedEvent.RetryCount)
 	})
 
 	t.Run("event published to retry channel with max retry count is persisted as error", func(t *testing.T) {

--- a/pkg/types.go
+++ b/pkg/types.go
@@ -28,7 +28,7 @@ type Event struct {
 	Error                *string `json:"error"`
 	ExternalID           string  `gorm:"not null" json:"externalId"`
 	Payload              string  `gorm:"not null" json:"payload"`
-	RetryCount           int32   `json:"retryCount"`
+	RetryCount           int     `json:"retryCount"`
 	Name                 string  `gorm:"not null" json:"name"`
 	UUID                 string  `gorm:"PRIMARY_KEY" json:"uuid"`
 }


### PR DESCRIPTION
Appearently in the newer version of oapi-codegen, the integer in Event.RetryCount changed from int32 to int.
Also the types param value was missing from generate instrcutions in the README.